### PR TITLE
The engine "node" is incompatible with this module. Expected version "5.0.0". Got "10.15.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ env:
 node_js:
   - "5"
   - "5.1"
+  - 11
+  - 10
+  - 8
+  - "10.15.0"
 after_script:
   - npm install codecov
   - ./node_modules/.bin/codecov

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jasmine-spec-reporter": "2.4.0"
   },
   "engines": {
-    "node": "5.0.0"
+    "node": ">=5.0.0"
   },
   "firedoc": {
     "linkNatives": true,


### PR DESCRIPTION
fix problems with newer node versions

error semver-increment@1.0.0: The engine "node" is incompatible with this module. Expected version "5.0.0". Got "10.15.0"